### PR TITLE
Add authenticity tokens to new experiment and sign up forms

### DIFF
--- a/app/views/experiments/_new.html.erb
+++ b/app/views/experiments/_new.html.erb
@@ -9,7 +9,7 @@
         </div>
           <div class="panel-body" id="create-exp">
 
-            <%= form_for @experiment, remote: true do |f| %>
+            <%= form_for @experiment, remote: true, authenticity_token: true do |f| %>
               <p>
                 <%= f.label :title %><br>
                 <%= f.text_field :title %>

--- a/app/views/experiments/_show.html.erb
+++ b/app/views/experiments/_show.html.erb
@@ -64,7 +64,7 @@
         </ul>
         <div class="sign-up-button">
           <% if @user.role.name == "Staff" && @experiment.staff.include?(@user) == false && @experiment.staff.count < @experiment.staff_size %>
-            <%= form_for experiment, url: {controller: 'experiments', action: "update"}, remote: true do |f| %>
+            <%= form_for experiment, url: {controller: 'experiments', action: "update"}, remote: true, authenticity_token: true do |f| %>
             <%= f.submit 'Sign Up For Experiment!', :class => 'btn btn-default' %>
             <% end %>
           <br>


### PR DESCRIPTION
- Using "remote: true" on a form takes away the default behavior of including a hidden authenticity token. Therefore, you need to explicitly state "authenticity_token: true" on the form so it adds that behavior back. I did that on both the new experiment form and the sign up for experiment form. 